### PR TITLE
Fix map div class

### DIFF
--- a/app/map/page.tsx
+++ b/app/map/page.tsx
@@ -38,7 +38,7 @@ export default function MapPage() {
         <Sidebar open={open} onClose={() => setOpen(false)}>
           <Search value={value} onValueChange={(v) => setValue(v)} ramenData={ramenData} onSearch={onSearch} />
         </Sidebar>
-        <div className='h-hull'>
+        <div className='h-full'>
           <Map onSearchToggle={() => setOpen(true)} onLoadRamenData={setRamenData} toRamen={ramen} />
         </div>
       </div>


### PR DESCRIPTION
## Summary
- correct typo in map page container div class

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68672a671b8483299c04350b1d558fdb